### PR TITLE
Relax extra constraint.

### DIFF
--- a/gipeda.cabal
+++ b/gipeda.cabal
@@ -79,7 +79,7 @@ executable gipeda
       gitlib               >= 3.1  && <3.2,
       gitlib-libgit2,
       tagged               >= 0.7  && <0.9,
-      extra                >= 1.1  && <1.2,
+      extra                >= 1    && <1.2,
 
       -- https://github.com/jwiegley/gitlib/issues/46
       conduit-combinators  < 1


### PR DESCRIPTION
It does not need to be >= 1.1, and the strict lower bound is causing a
bit of trouble in our production environment.
