### PR TITLE
Small fix for not existing git repo in logs directory

### DIFF
--- a/src/Shake.hs
+++ b/src/Shake.hs
@@ -84,7 +84,7 @@ determineLogSource = do
     haveLogs <- System.Directory.doesDirectoryExist "logs"
     if haveLogs
     then do
-        (Exit _, Stdout s) <- cmd "git -C logs rev-parse --is-bare-repository"
+        (Exit _, Stdout s, Stderr _) <- cmd "git -C logs rev-parse --is-bare-repository"
         if s == "true\n"
         then return BareGit
         else return FileSystem


### PR DESCRIPTION
Before, if no git repo was found at all, for example if gipeda is run in a docker container
and logs are mounted from outside, the expression would cause the program to exit at that point.
