### PR TITLE
Fixed ambiguous type for CmdString in Shake.hs

### DIFF
--- a/example/settings.yaml
+++ b/example/settings.yaml
@@ -1,4 +1,5 @@
 title: Gipeda itself
+diffLink:
 revisionInfo: '<a href="https://github.com/nomeata/gipeda/commit/{{rev}}">View Diff</a>'
 limitRecent: 20
 start: 65b3eede043ff5d4718724d220a82bbc8adc3280

--- a/src/Shake.hs
+++ b/src/Shake.hs
@@ -84,7 +84,7 @@ determineLogSource = do
     haveLogs <- System.Directory.doesDirectoryExist "logs"
     if haveLogs
     then do
-        (Exit _, Stdout s, Stderr _) <- cmd "git -C logs rev-parse --is-bare-repository"
+        (Exit _, Stdouterr s) <- cmd "git -C logs rev-parse --is-bare-repository"
         if s == "true\n"
         then return BareGit
         else return FileSystem


### PR DESCRIPTION
Commit e184291 introduced an ambiguous type error in Shake.hs:

```
src/Shake.hs:87:41:
    No instance for (CmdString t0) arising from a use of ‘cmd’
    The type variable ‘t0’ is ambiguous
    Note: there are several potential instances:
      instance CmdString BS.ByteString
        -- Defined in ‘Development.Shake.Command’
      instance CmdString LBS.ByteString
        -- Defined in ‘Development.Shake.Command’
      instance CmdString () -- Defined in ‘Development.Shake.Command’
      ...plus one other
    In a stmt of a 'do' block:
      (Exit _, Stdout s, Stderr _) <- cmd
                                        "git -C logs rev-parse --is-bare-repository"
    In the expression:
      do { (Exit _, Stdout s, Stderr _) <- cmd
                                             "git -C logs rev-parse --is-bare-repository";
           if s == "true\n" then return BareGit else return FileSystem }
    In a stmt of a 'do' block:
      if haveLogs then
          do { (Exit _, Stdout s, Stderr _) <- cmd
                                                 "git -C logs rev-parse --is-bare-repository";
               if s == "true\n" then return BareGit else return FileSystem }
      else
          return NoLogs
```

This error is caused by the addition of `, Stderr _` to the resulting tuple of the call to `cmd` in question.

This change collects both stdout and stderr into the string s. Since the stderr output was never used, the behavior of this function should remain the same.
