### PR TITLE
Use the absolute path to the executable instead of './gipeda' for sub commands

### DIFF
--- a/src/Shake.hs
+++ b/src/Shake.hs
@@ -14,6 +14,7 @@ import System.IO.Extra (newTempFile)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified System.Directory
+import System.Environment (getExecutablePath)
 import Data.Aeson
 import qualified Data.Text as T
 
@@ -36,7 +37,8 @@ git gitcmd args = do
 self :: (CmdResult b) => String -> [String] -> Action b
 self name args = do
     -- orderOnly ["gipeda"]
-    cmd (Traced name) "./gipeda" name args
+    gipeda <- liftIO getExecutablePath
+    cmd (Traced name) gipeda name args
 
 gitRange :: Action [String]
 gitRange = do


### PR DESCRIPTION
The hope is that it fixes usage of the -C flag and gets rid off the requirement of always having to create a link to the gipeda executable in the working directory.

Example error without this:

```
$ pwd
/path/to/gipeda/installation
$ ./gipeda -C path/to/project/dir
# JsonSettings (for site/out/settings.json)
Error when running Shake build system:
* site/out/settings.json
user error (Development.Shake.cmd, system command failed
Command: ./gipeda JsonSettings
./gipeda: createProcess: runInteractiveProcess: exec: does not exist (No such file or directory))
```

(Same for `$ /path/to/gipeda/installation/gipeda` with cwd `/path/to/project/dir`, I guess)

I grepped for other usages of './gipeda' and haven't found any other than this.

Note that `getExecutablePath` is part of `base` since 4.6.0.0, so it should be compatible with the lower version bound in gipeda.cabal.
