### PR TITLE
Rewrite .travis to use stack 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,73 @@
 # NB: don't set `language: haskell` here
 
-# These are the versions that we built against, at least once, on travis
-env:
- - CABALVER=1.18 GHCVER=7.6.3
- - CABALVER=1.18 GHCVER=7.8.3
- - CABALVER=1.22 GHCVER=7.10.2
- - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
+sudo: false
+cache:
+  directories:
+  - $HOME/.stack/
 
+# Here we test both stack builds, which offer a controlled package
+# set, and "bleeding edge" builds which use the GHC resolver to grab
+# the latest off hackage.
 matrix:
+  include:
+    # Default: Use whichever is embedded in stack.yaml currently:
+    - env: STACK_RESOLVER=
+      addons: {apt: {packages: [libgmp-dev]}}
+
+    # Test with an older GHC, 7.8.4:
+    - env: STACK_RESOLVER=lts-2.22
+      addons: {apt: {packages: [ghc-7.8.4,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
+      
+    # This is nondeterministic; the latest nightly:
+    - env: STACK_RESOLVER=nightly
+      addons: {apt: {packages: [libgmp-dev]}}
+
+    # Try to use the very latest packages here, so that we catch
+    # failures before they get to stackage:
+    - env: STACK_RESOLVER=ghc-7.8
+      addons: {apt: {packages: [ghc-7.8.4,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
+    - env: STACK_RESOLVER=ghc-7.10
+      addons: {apt: {packages: [ghc-7.10.1,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
+
   allow_failures:
-    - env: CABALVER=head GHCVER=head
+    # We should track these failures, but they don't represent a
+    # change or regression in our code:
+    - env: STACK_RESOLVER=ghc-7.8
+    - env: STACK_RESOLVER=ghc-7.10
+    - env: STACK_RESOLVER=nightly
+      
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - mkdir -p ~/.local/bin
+ - export PATH=~/.local/bin:$PATH
+ - export STACK_YAML=stack-${STACK_RESOLVER}.yaml
+ 
+ - wget https://github.com/commercialhaskell/stack/releases/download/v1.0.4/stack-1.0.4.2-linux-x86_64.tar.gz
+ - tar xvf stack-1.0.4.2-linux-x86_64.tar.gz
+ - mv -f stack-1.0.4.2-linux-x86_64/stack ~/.local/bin/
+ - chmod a+x ~/.local/bin/stack
 
 install:
- - cabal --version
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH  
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - travis_retry cabal update
  - cabal install --only-dependencies --enable-tests --enable-benchmarks
+ 
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
- - cabal build   # this builds all libraries and executables (including tests/benchmarks)
- - cabal test
+ - stack test --no-terminal
+ - stack benchmark 
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 
 # The following scriptlet checks that the resulting source distribution can be built & installed
- - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
-   cd dist/;
-   if [ -f "$SRC_TGZ" ]; then
-      cabal install --force-reinstalls "$SRC_TGZ";
-   else
-      echo "expected '$SRC_TGZ' not found";
-      exit 1;
-   fi
+ # - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
+ #   cd dist/;
+ #   if [ -f "$SRC_TGZ" ]; then
+ #      cabal install --force-reinstalls "$SRC_TGZ";
+ #   else
+ #      echo "expected '$SRC_TGZ' not found";
+ #      exit 1;
+ #   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,7 @@ before_install:
 install:
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH  
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - cabal install --only-dependencies --enable-tests --enable-benchmarks
- 
+ - $STACK build
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 
     # Test with an older GHC, 7.8.4:
     - env: STACK_RESOLVER=lts-2.22
+           STACK_YAML=stack-lts-2.22.yaml
       addons: {apt: {packages: [libgmp-dev]}}      
       
     # This is nondeterministic; the latest nightly:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
  - $STACK test --no-terminal
- - $STACK benchmark
+ - $STACK bench
  - $STACK build cabal-install
  - $STACK exec cabal check
  - $STACK exec cabal sdist   # tests that a source-distribution can be generated

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,8 @@ install:
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
  - $STACK test --no-terminal
- - $STACK benchmark 
+ - $STACK benchmark
+ - $STACK build cabal-install
  - $STACK exec cabal check
  - $STACK exec cabal sdist   # tests that a source-distribution can be generated
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,19 +52,20 @@ before_install:
    then STACK=stack;
    else STACK="stack --resolver=$STACK_RESOLVER";
    fi
- # These are expected to be nondeterministic, so try to solve with the latest:
- - if [ "$STACK_RESOLVER" == ghc-7.8 ] ||
-      [ "$STACK_RESOLVER" == ghc-7.10 ]; 
-   then $STACK solver --update-config ;
-   fi
- - wget https://github.com/commercialhaskell/stack/releases/download/v1.0.4/stack-1.0.4.2-linux-x86_64.tar.gz
- - tar xvf stack-1.0.4.2-linux-x86_64.tar.gz
- - mv -f stack-1.0.4.2-linux-x86_64/stack ~/.local/bin/
+ - export STACKVER=1.0.4.2
+ - wget https://github.com/commercialhaskell/stack/releases/download/v1.0.4/stack-${STACKVER}-linux-x86_64.tar.gz
+ - tar xvf stack-${STACKVER}-linux-x86_64.tar.gz
+ - mv -f stack-${STACKVER}-linux-x86_64/stack ~/.local/bin/
  - chmod a+x ~/.local/bin/stack
 
 install:
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH  
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ # These two are expected to be nondeterministic, so try to solve with the latest:
+ - if [ "$STACK_RESOLVER" == ghc-7.8 ] ||
+      [ "$STACK_RESOLVER" == ghc-7.10 ]; 
+   then $STACK solver --update-config ;
+   fi 
  - $STACK setup
  - $STACK build
  - $STACK build cabal-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,11 @@ before_install:
    then STACK=stack;
    else STACK="stack --resolver=$STACK_RESOLVER";
    fi
+ # These are expected to be nondeterministic, so try to solve with the latest:
+ - if [ "$STACK_RESOLVER" == ghc-7.8 ] ||
+      [ "$STACK_RESOLVER" == ghc-7.10 ]; 
+   then $STACK solver --update-config ;
+   fi
  - wget https://github.com/commercialhaskell/stack/releases/download/v1.0.4/stack-1.0.4.2-linux-x86_64.tar.gz
  - tar xvf stack-1.0.4.2-linux-x86_64.tar.gz
  - mv -f stack-1.0.4.2-linux-x86_64/stack ~/.local/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,10 @@ matrix:
 before_install:
  - mkdir -p ~/.local/bin
  - export PATH=~/.local/bin:$PATH
- - export STACK_YAML=stack-${STACK_RESOLVER}.yaml
+ - if [ "$STACK_RESOLVER" == "" ];
+   then STACK=stack;
+   else STACK="stack --resolver=$STACK_RESOLVER"
+   fi
  
  - wget https://github.com/commercialhaskell/stack/releases/download/v1.0.4/stack-1.0.4.2-linux-x86_64.tar.gz
  - tar xvf stack-1.0.4.2-linux-x86_64.tar.gz
@@ -57,8 +60,8 @@ install:
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - stack test --no-terminal
- - stack benchmark 
+ - $STACK test --no-terminal
+ - $STACK benchmark 
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,12 +61,12 @@ before_install:
 install:
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH  
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - $STACK setup 
  # These two are expected to be nondeterministic, so try to solve with the latest:
  - if [ "$STACK_RESOLVER" == ghc-7.8 ] ||
       [ "$STACK_RESOLVER" == ghc-7.10 ]; 
    then $STACK solver --update-config ;
    fi 
- - $STACK setup
  - $STACK build
  - $STACK build cabal-install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,22 +56,19 @@ install:
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - $STACK setup
  - $STACK build
+ - $STACK build cabal-install
 
-# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
  - $STACK test --no-terminal
  - $STACK bench
- - $STACK build cabal-install
- - $STACK exec cabal check
- - $STACK exec cabal sdist   # tests that a source-distribution can be generated
+ - $STACK exec cabal -- check
+ - $STACK exec cabal -- sdist   # tests that a source-distribution can be generated
 
-# The following scriptlet checks that the resulting source distribution can be built & installed
- # - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
- #   cd dist/;
- #   if [ -f "$SRC_TGZ" ]; then
- #      cabal install --force-reinstalls "$SRC_TGZ";
- #   else
- #      echo "expected '$SRC_TGZ' not found";
- #      exit 1;
- #   fi
+ # This will, painfully, rebuild all the deps in ./.stack-work
+ - cd dist;  tar xf *.gz;  rm -f *.gz; 
+   cd gipeda-*/; 
+   cp ../../stack*.yaml . ;
+   $STACK build 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 
     # Test with an older GHC, 7.8.4:
     - env: STACK_RESOLVER=lts-2.22
-      addons: {apt: {packages: [ghc-7.8.4,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
+#      addons: {apt: {packages: [ghc-7.8.4,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
       
     # This is nondeterministic; the latest nightly:
     - env: STACK_RESOLVER=nightly
@@ -25,9 +25,9 @@ matrix:
     # Try to use the very latest packages here, so that we catch
     # failures before they get to stackage:
     - env: STACK_RESOLVER=ghc-7.8
-      addons: {apt: {packages: [ghc-7.8.4,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
+#      addons: {apt: {packages: [ghc-7.8.4,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
     - env: STACK_RESOLVER=ghc-7.10
-      addons: {apt: {packages: [ghc-7.10.1,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
+#      addons: {apt: {packages: [ghc-7.10.1,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
 
   allow_failures:
     # We should track these failures, but they don't represent a
@@ -53,6 +53,7 @@ before_install:
 install:
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH  
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - $STACK setup
  - $STACK build
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
@@ -60,8 +61,8 @@ script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
  - $STACK test --no-terminal
  - $STACK benchmark 
- - cabal check
- - cabal sdist   # tests that a source-distribution can be generated
+ - $STACK exec cabal check
+ - $STACK exec cabal sdist   # tests that a source-distribution can be generated
 
 # The following scriptlet checks that the resulting source distribution can be built & installed
  # - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 
     # Test with an older GHC, 7.8.4:
     - env: STACK_RESOLVER=lts-2.22
-#      addons: {apt: {packages: [ghc-7.8.4,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
+      addons: {apt: {packages: [libgmp-dev]}}      
       
     # This is nondeterministic; the latest nightly:
     - env: STACK_RESOLVER=nightly
@@ -25,9 +25,9 @@ matrix:
     # Try to use the very latest packages here, so that we catch
     # failures before they get to stackage:
     - env: STACK_RESOLVER=ghc-7.8
-#      addons: {apt: {packages: [ghc-7.8.4,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
+      addons: {apt: {packages: [libgmp-dev]}}      
     - env: STACK_RESOLVER=ghc-7.10
-#      addons: {apt: {packages: [ghc-7.10.1,happy-1.19.4,alex-3.1.3],sources: [hvr-ghc]}}
+      addons: {apt: {packages: [libgmp-dev]}}
 
   allow_failures:
     # We should track these failures, but they don't represent a

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,8 @@ before_install:
  - export PATH=~/.local/bin:$PATH
  - if [ "$STACK_RESOLVER" == "" ];
    then STACK=stack;
-   else STACK="stack --resolver=$STACK_RESOLVER"
+   else STACK="stack --resolver=$STACK_RESOLVER";
    fi
- 
  - wget https://github.com/commercialhaskell/stack/releases/download/v1.0.4/stack-1.0.4.2-linux-x86_64.tar.gz
  - tar xvf stack-1.0.4.2-linux-x86_64.tar.gz
  - mv -f stack-1.0.4.2-linux-x86_64/stack ~/.local/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,13 @@ matrix:
     - env: STACK_RESOLVER=ghc-7.8
     - env: STACK_RESOLVER=ghc-7.10
     - env: STACK_RESOLVER=nightly
-      
+
+    # This one is failing with:
+    #  /tmp/stack4926/gitlib-libgit2-2.2.0.1/Git/Libgit2/Types.hs:51:21:
+    #   Not in scope: type constructor or class ‘MonadThrow’
+    # Joachim can decide if he wants to support 7.8.4:
+    - env: STACK_RESOLVER=lts-2.22
+           STACK_YAML=stack-lts-2.22.yaml      
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 
-# FROM ubuntu:15.10
-FROM fpco/stack-build:lts-5.13
+FROM fpco/stack-build:lts-5.18
 
 RUN apt-get update --yes
 RUN apt-get install --yes git unzip libssl-dev libfile-slurp-perl libipc-run-perl libicu-dev
 
 ADD ./ /gipeda
 
-RUN cd /gipeda && stack install --install-ghc --local-bin-path=.
-
-
+RUN cd /gipeda && \
+    stack install --install-ghc --local-bin-path=/usr/bin && \
+    cp -a install-jslibs.sh /usr/bin && \
+    rm -rf /gipeda

--- a/stack-lts-2.22.yaml
+++ b/stack-lts-2.22.yaml
@@ -1,0 +1,44 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+
+# This isn't a great way to support LTS-2.22, but it is GHC 7.8 at least:
+extra-deps:
+- StateVar-1.1.0.4
+- adjunctions-4.3
+- base-orphans-0.5.4
+- bifunctors-5.3
+- bindings-DSL-1.0.23
+- comonad-5
+- concurrent-output-1.7.6
+- conduit-1.2.6.6
+- conduit-combinators-1.0.3.1
+- conduit-extra-1.1.13.1
+- contravariant-1.4
+- distributive-0.5.0.2
+- exceptions-0.8.2.1
+- failure-0.2.0.3
+- fast-logger-2.4.6
+- file-embed-0.0.10
+- free-4.12.4
+- gitlib-3.1.1
+- gitlib-libgit2-2.2.0.1
+- kan-extensions-5.0.1
+- keys-3.11
+- mmorph-1.0.6
+- mono-traversable-0.10.2
+- mtl-2.2.1
+- pointed-5
+- primitive-0.6.1.0
+- profunctors-5.2
+- resourcet-1.1.7.4
+- semigroupoids-5.0.1
+- transformers-0.5.2.0
+- transformers-compat-0.5.1.4
+- unix-time-0.3.6
+- vector-0.11.0.0
+- vector-algorithms-0.7.0.1
+- vector-instances-3.3.1
+- yaml-0.8.12
+resolver: lts-2.22


### PR DESCRIPTION
Hi @nomeata,

This new travis file aims to preserve the functionality of the original .travis setup, except it drops 7.6 support.

[The 7.10.3 build is passing fine.](https://travis-ci.org/iu-parfunc/gipeda/jobs/133369021)

In contrast, 7.8 is [currently getting a build error in gitlib-libgit2](https://travis-ci.org/iu-parfunc/gipeda/jobs/133369022), and it's the same error you are seeing on your current travis, e.g. [here](https://travis-ci.org/nomeata/gipeda/jobs/132879622).  You an decide whether you want to debug that or not, but I've marked it as an allowed failure for now.

This setup aims to test five different configs:
- deterministic: Stackage 7.10 series
- deterministic: Stackage 7.8 series (lts-2.22) -- currently broken
- nondeterministic: Stackage nightly -- track the current stackage, currently GHC 8.0 and failing.  Some work is needed to support 8.0.
- nondeterministic: ghc-7.10 resolver -- i.e. use the latest packages and see what breaks
- nondeterministic: ghc-7.8 resolver -- i.e. use the latest packages and see what breaks

Travis does not directly test the docker file.  Travis could do that, but then you must run in a full VM and lose the ability to cache `~/.stack`.  Also, it becomes a real pain to vary the settings as above.  It would amount to a bunch of inplace sed hacks on the Dockerfile, or generation of multiple Dockerfiles.

The Dockerfile is designed for a different purpose currently -- giving a binary distribution where people can get the gipeda executable trivially.  And then build their own websites reproducibly inside a container.

The better test for the Dockerfile is whether the automated builds on Dockerhub are building.  E.g. [here is the build history for this fork](https://hub.docker.com/r/parfunc/gipeda/builds/).  Unfortunately, the support for "badges" for dockerhub is currently a hack.

For tagging Docker images, I would like to use the same version numbers as used in the hackage releases.  In that build history you can see that I've currently named the tag "post0.2.0.1" because I know the HEAD is somewhere past that release.  Can you say exactly which commit corresponds to version 0.2.0.1 on hackage?  Is it [this one](https://github.com/nomeata/gipeda/commit/109eb1e01b3d6b68c57ce68cb8728e9b0d2d75f9)?  That was the commit that changed the version number to 0.2.0.1.

Alas, for setting up Dockerhub automated builds for `nomeata/gipeda` I cannot help you.  It seems it has the same problem as travis, which I think is based on a common github limitation.  Collaborators, weirdly, can't have "admin" access.  Thus my dockerhub account, authenticated as me on github, can't set anything up automatically.  Not unless the repo is moved to an organization and I'm granted admin perms on it.

But if you want to set up builds of `nomeata/gipeda` directly, it is really trivial.  Just as easy as travis.  Just make a `nomeata` account, connect to your github, and click "Create Automated Build" at the top right.  Then just click on the name of the repo, and you're good to go.
