### PR TITLE
Append the start commit to the `gitRange`

### DIFF
--- a/src/Shake.hs
+++ b/src/Shake.hs
@@ -48,8 +48,8 @@ gitRange = do
     s <- liftIO $ S.readSettings "gipeda.yaml"
     let first = S.start s
     heads <- readFileLines "site/out/heads.txt"
-    Stdout range <- git "log" $ ["--format=%H","^"++first] ++ heads
-    return $ words range ++ [first]
+    Stdout range <- git "log" $ ["--format=%H","^"++first++"^@"] ++ heads
+    return $ words range
 
 needIfThere :: [FilePath] -> Action [FilePath]
 needIfThere files = do
@@ -197,7 +197,7 @@ shakeMain = do
         let first = S.start s
 
         Stdout stdout <- git "log" $
-                "--format=%H;%P": ("^"++first) : heads
+                "--format=%H;%P": ("^"++first++"^@") : heads
         writeFileChanged out stdout
     want ["site/out/history.csv"]
 

--- a/src/Shake.hs
+++ b/src/Shake.hs
@@ -49,7 +49,7 @@ gitRange = do
     let first = S.start s
     heads <- readFileLines "site/out/heads.txt"
     Stdout range <- git "log" $ ["--format=%H","^"++first] ++ heads
-    return $ words range
+    return $ words range ++ [first]
 
 needIfThere :: [FilePath] -> Action [FilePath]
 needIfThere files = do


### PR DESCRIPTION
And thereby fix #48. Seems to be the cleanest solution, as I don't know of a way to specify a git range that does the same thing reliably.

Appending should be the right thing to do, as its probably the oldest commit.
