### PR TITLE
Improve rendering of values

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -488,9 +488,9 @@ html {
           <tr>
           <th class="col-xs-5">Benchmark name</th>
           <th class="col-xs-2 text-right">previous</th>
-          <th class="col-xs-2 text-right">change</th>
           <th class="col-xs-2 text-right">now</th>
           <th class="col-xs-1 text-left"></th>
+          <th class="col-xs-2 text-right">change</th>
           </tr>
           </thead>
           <tbody>
@@ -507,9 +507,9 @@ html {
 	     </a>
 	    </td>
             <td class="text-right">{{previous}}</td>
-            <td class="text-right">{{change}}</td>
             <td class="text-right">{{value}}</td>
             <td class="text-left">{{unit}}</td>
+            <td class="text-right">{{change}}</td>
             </tr>
            {{/each}}
           </tbody>
@@ -596,9 +596,9 @@ html {
           <tr>
           <th class="col-xs-5">Benchmark name</th>
           <th class="col-xs-2 text-right">previous</th>
-          <th class="col-xs-2 text-right">change</th>
           <th class="col-xs-2 text-right">now</th>
           <th class="col-xs-1 text-right"></th>
+          <th class="col-xs-2 text-right">change</th>
           </tr>
           </thead>
           <tbody>
@@ -615,9 +615,9 @@ html {
 	     </a>
 	    </td>
             <td class="text-right">{{previous}}</td>
-            <td class="text-right">{{change}}</td>
             <td class="text-right">{{value}}</td>
             <td class="text-left">{{unit}}</td>
+            <td class="text-right">{{change}}</td>
             </tr>
            {{/each}}
           </tbody>

--- a/site/index.html
+++ b/site/index.html
@@ -352,7 +352,7 @@ html {
        <div class="panel-heading" role="tab" id="heading-{{@index}}">
         <h4 class="panel-title">
          <a class="accordion-toggle" data-toggle="collapse" href="#table-{{@index}}">
-         {{groupName}}
+         {{groupName}}{{#if unitFull}}, {{unitFull}}{{/if}}
          </a>
         </h4>
        </div>
@@ -471,7 +471,7 @@ html {
        <div class="panel-heading" role="tab" id="heading-{{@index}}">
         <h4 class="panel-title">
          <a class="accordion-toggle" data-toggle="collapse" href="#table-{{@index}}">
-         {{groupName}}
+         {{groupName}}{{#if unitFull}}, {{unitFull}}{{/if}}
          <span class="stats pull-right">
           {{> summary-icons groupStats}}
           <span class="indicator-toggled glyphicon glyphicon-chevron-down text-grey"/>
@@ -579,7 +579,7 @@ html {
        <div class="panel-heading" role="tab" id="heading-{{@index}}">
         <h4 class="panel-title">
          <a class="accordion-toggle" data-toggle="collapse" href="#table-{{@index}}">
-         {{groupName}}
+         {{groupName}}{{#if unitFull}}, {{unitFull}}{{/if}}
          <span class="stats pull-right">
           {{> summary-icons groupStats}}
           <span class="indicator-toggled glyphicon glyphicon-chevron-down text-grey"/>

--- a/site/js/gipeda.js
+++ b/site/js/gipeda.js
@@ -466,6 +466,8 @@ function calculate_groups(rev1, rev2) {
       }).filter(function (br) {return br;});
       return {
 	groupName: group.groupName || "Benchmarks",
+    unit: group.groupUnit,
+    unitFull: group.groupUnitFull,
 	benchResults: benchmarks,
 	groupStats: groupStats(benchmarks),
       };

--- a/site/js/gipeda.js
+++ b/site/js/gipeda.js
@@ -358,6 +358,7 @@ function setting_for(name) {
     return benchSettings;
 }
 
+var unitPrefix = [["G", 9], ["M", 6], ["k", 3], ["", 0], ["m", -3], ["u", -6], ["n", -9]]
 
 // The following logic should be kept in sync with toResult in ReportTypes.hs
 function compareResults (res1, res2) {
@@ -366,11 +367,27 @@ function compareResults (res1, res2) {
     var name = res1? res1.name : res2.name;
     var s = setting_for(name);
 
+    var value1 = res1 ? res1.value : null;
+    var value2 = res2 ? res2.value : null;
+    var unit = s.unit;
+
+    for (var i = 0; i < unitPrefix.length; i++) {
+        var magnitude = Math.pow(10, unitPrefix[i][1]);
+        if (i == unitPrefix.length - 1
+          || ( (value1 === null || value1 > magnitude)
+            && (value2 === null || value2 > magnitude))) {
+          if (value1 !== null) { value1 = (value1 / magnitude).toFixed(2); }
+          if (value2 !== null) { value2 = (value2 / magnitude).toFixed(2); }
+          unit = unitPrefix[i][0] + unit;
+          break;
+        }
+    }
+
     var res = {
         name: name,
-        previous:    res1 ? res1.value : null,
-        value:       res2 ? res2.value : null,
-        unit:        s.unit,
+        previous:    value1,
+        value:       value2,
+        unit:        unit,
         important:   s.important,
         changeType: "Boring",
         change: "foobar",
@@ -434,10 +451,22 @@ function singleResult (res) {
     var name = res.name;
     var s = setting_for(name);
 
+    var value = res.value;
+    var unit = s.unit;
+
+    for (var i = 0; i < unitPrefix.length; i++) {
+        var magnitude = Math.pow(10, unitPrefix[i][1]);
+        if (i == unitPrefix.length - 1 || value > magnitude) {
+          value /= magnitude;
+          unit = unitPrefix[i][0] + unit;
+          break;
+        }
+    }
+
     return  {
         name: name,
         previous:    null,
-        value:       res.value,
+        value:       value.toFixed(2),
         unit:        s.unit,
         important:   s.important,
         changeType: "Boring",

--- a/src/BenchNames.hs
+++ b/src/BenchNames.hs
@@ -3,6 +3,7 @@ module BenchNames where
 
 import qualified Data.ByteString.Lazy as BS
 import Data.Aeson
+import Control.Applicative
 import Control.Monad
 import qualified Data.Map as M
 import qualified Data.Text as T
@@ -19,12 +20,16 @@ benchNamesMain benchNames = do
     settings <- S.readSettings "gipeda.yaml"
 
     let groups =
-            map (uncurry BenchGroup) $
-            sort $
+            sortOn (liftA2 (,) groupName groupMembers) $
+            map (\(name, (s, bns)) -> BenchGroup
+              { groupName = name
+              , groupMembers = bns
+              , groupUnitFull = S.unitFull s
+              }) $
             M.toList $
-            M.map sort $
-            M.fromListWith (++)
-                [ (S.group s, [bn])
+            M.map (fmap sort) $
+            M.fromListWith (\(s, bns) (_, bns') -> (s, bns ++ bns'))
+                [ (S.group s, (s, [bn]))
                 | bn <- benchNames
                 , let s = S.benchSettings settings bn
                 ]

--- a/src/BenchmarkSettings.hs
+++ b/src/BenchmarkSettings.hs
@@ -24,6 +24,7 @@ type BenchName = String
 data BenchSettings = BenchSettings
     { smallerIsBetter :: Bool
     , unit :: String
+    , unitFull :: Maybe String
     , numberType :: NumberType
     , group :: String
     , threshold :: Double
@@ -33,7 +34,7 @@ data BenchSettings = BenchSettings
 instance ToJSON BenchSettings
 
 defaultBenchSettings :: BenchSettings
-defaultBenchSettings = BenchSettings True "" IntegralNT "" 3 True
+defaultBenchSettings = BenchSettings True "" Nothing IntegralNT "" 3 True
 
 newtype S = S { unS :: BenchName -> BenchSettings }
 newtype SM = SM (BenchName -> (BenchSettings -> BenchSettings))
@@ -60,6 +61,7 @@ instance FromJSON SM where
         m <- o .: "match"
         mt <- o .:? "type"
         mu <- o .:? "unit"
+        muf <- o.:? "unitFull"
         mg <- o .:? "group"
         ms <- o .:? "smallerIsBetter"
         mth <- o .:? "threshold"
@@ -68,6 +70,7 @@ instance FromJSON SM where
             if n `matches` m then
                b { numberType      = fromMaybe (numberType b) mt
                  , unit            = fromMaybe (unit b) mu
+                 , unitFull        = muf
                  , group           = fromMaybe (group b) mg
                  , smallerIsBetter = fromMaybe (smallerIsBetter b) ms
                  , threshold       = fromMaybe (threshold b) mth

--- a/src/BenchmarkSettings.hs
+++ b/src/BenchmarkSettings.hs
@@ -25,6 +25,7 @@ data BenchSettings = BenchSettings
     { smallerIsBetter :: Bool
     , unit :: String
     , unitFull :: Maybe String
+    , rescalable :: Bool
     , numberType :: NumberType
     , group :: String
     , threshold :: Double
@@ -33,8 +34,9 @@ data BenchSettings = BenchSettings
     deriving (Show, Generic)
 instance ToJSON BenchSettings
 
+-- Keep in sync with setting_for() in gipeda.js
 defaultBenchSettings :: BenchSettings
-defaultBenchSettings = BenchSettings True "" Nothing IntegralNT "" 3 True
+defaultBenchSettings = BenchSettings True "" Nothing False IntegralNT "" 3 True
 
 newtype S = S { unS :: BenchName -> BenchSettings }
 newtype SM = SM (BenchName -> (BenchSettings -> BenchSettings))
@@ -62,6 +64,7 @@ instance FromJSON SM where
         mt <- o .:? "type"
         mu <- o .:? "unit"
         muf <- o.:? "unitFull"
+        mr <- o .:? "rescalable"
         mg <- o .:? "group"
         ms <- o .:? "smallerIsBetter"
         mth <- o .:? "threshold"
@@ -71,6 +74,7 @@ instance FromJSON SM where
                b { numberType      = fromMaybe (numberType b) mt
                  , unit            = fromMaybe (unit b) mu
                  , unitFull        = muf
+                 , rescalable      = fromMaybe (rescalable b) mr
                  , group           = fromMaybe (group b) mg
                  , smallerIsBetter = fromMaybe (smallerIsBetter b) ms
                  , threshold       = fromMaybe (threshold b) mth

--- a/src/ReportTypes.hs
+++ b/src/ReportTypes.hs
@@ -109,6 +109,7 @@ instance FromJSON ChangeType
 data BenchGroup = BenchGroup
     { groupName :: String
     , groupMembers :: [BenchName]
+    , groupUnitFull :: Maybe String
     }
  deriving (Generic)
 instance ToJSON BenchGroup


### PR DESCRIPTION
Builds on top of @50. There are three parts to this PR, I'm not sure whether it would have been better to split them.

- Full unit name at the top after the group name, useful for benchmarks with exotic units, so we can use abbreviations in the rest of the table;
- Automatic scaling and rounding to standard magnitudes, perhaps this should be switchable by a flag, as this doesn't make much sense for benchmarks with exact expected values (like the nofib allocation tests);
- Reordered columns for easier comparison of previous/now.

![sc-2017-11-15t23 11 10-05 00](https://user-images.githubusercontent.com/2515201/32873496-61175a74-ca5a-11e7-9026-0cb9048c2659.png)
