### PR TITLE
Relax bound on base to allow building with GHC 8.2

### DIFF
--- a/gipeda.cabal
+++ b/gipeda.cabal
@@ -64,7 +64,7 @@ executable gipeda
 
 
   build-depends:
-      base                 >= 4.6   && <4.10,
+      base                 >= 4.6   && <4.11,
       bytestring           >= 0.10  && <0.11,
       containers           >= 0.4   && <0.6,
       directory            >= 1.2   && <1.4,


### PR DESCRIPTION
When building with 8.2 `gitlib` master is needed, see https://github.com/jwiegley/gitlib/issues/77, but gipeda builds just fine.