### PR TITLE
Switch to sha256 over https for flotcharts

### DIFF
--- a/install-jslibs.sh
+++ b/install-jslibs.sh
@@ -26,7 +26,8 @@ test -d jquery-ui || {
 test -e jquery.timeago.js ||
 	wget -c https://timeago.yarp.com/jquery.timeago.js
 test -d flot || {
-	wget -c https://www.flotcharts.org/downloads/flot-0.8.3.zip
+	wget -c http://www.flotcharts.org/downloads/flot-0.8.3.zip
+	echo "ca33e0e707b0ac48f8962baaab321a006ef35cf73ea5bece95a30f23d49b9f31  flot-0.8.3.zip" | sha256sum -c
 	unzip flot-0.8.3.zip
 	rm -f flot-0.8.3.zip
 }


### PR DESCRIPTION
Flotcharts doesn't have a valid SSL certificate, so having https here breaks gipeda. Switch to SHA256 just like we're doing for handlebars.