### PR TITLE
Compatibility with GHC 8.4/Shake 0.16 and newer

### DIFF
--- a/gipeda.cabal
+++ b/gipeda.cabal
@@ -64,26 +64,26 @@ executable gipeda
 
 
   build-depends:
-      base                 >= 4.6   && <4.11,
+      base                 >= 4.6   && <4.13,
       bytestring           >= 0.10  && <0.11,
-      containers           >= 0.4   && <0.6,
+      containers           >= 0.4   && <0.7,
       directory            >= 1.2   && <1.4,
       filepath             >= 1.3   && <1.5,
-      shake                >= 0.13  && <0.16,
+      shake                >= 0.13  && <0.18,
       text                 >= 0.11  && <1.3,
       unordered-containers >= 0.2   && <0.3,
       split                >= 0.2   && <0.3,
       vector               >= 0.10  && <0.13,
-      cassava              >= 0.4   && <0.5,
-      yaml                 >= 0.8   && <0.9,
-      aeson                >= 0.7   && <1.3,
+      cassava              >= 0.4   && <0.6,
+      yaml                 >= 0.8   && <0.12,
+      aeson                >= 0.7   && <1.5,
       scientific           >= 0.3   && <0.4,
       gitlib               >= 3.1.0.2 && <3.2,
       gitlib-libgit2,
       tagged               >= 0.7   && <0.9,
-      extra                >= 1     && <1.6,
-      file-embed           >= 0.0.9 && < 0.0.11,
-      concurrent-output    >= 1.7   && < 1.8,
+      extra                >= 1     && <1.7,
+      file-embed           >= 0.0.9 && < 0.0.12,
+      concurrent-output    >= 1.7   && < 1.11,
       transformers         >= 0.4   && < 0.6
 
   hs-source-dirs: src

--- a/src/BenchmarkSettings.hs
+++ b/src/BenchmarkSettings.hs
@@ -41,9 +41,11 @@ defaultBenchSettings = BenchSettings True "" Nothing False IntegralNT "" 3 True
 newtype S = S { unS :: BenchName -> BenchSettings }
 newtype SM = SM (BenchName -> (BenchSettings -> BenchSettings))
 
+instance Semigroup SM where
+    (<>) (SM f) (SM g) = SM (\n -> g n . f n)
+
 instance Monoid SM where
     mempty = SM (const id)
-    mappend (SM f) (SM g) = SM (\n -> g n . f n)
 
 instance FromJSON NumberType where
     parseJSON = withText "type" $ \t -> case t of

--- a/src/Development/Shake/Fancy.hs
+++ b/src/Development/Shake/Fancy.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, ConstraintKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, ConstraintKinds, TypeFamilies #-}
 module Development.Shake.Fancy
     ( module Development.Shake
 
@@ -172,7 +172,7 @@ cmdWrap :: String -> S.Action a -> Action a
 cmdWrap cmd act =
     describe (quietly act) '!' ("running " ++ cmd)
 
-addOracle :: (S.ShakeValue q, S.ShakeValue a) => (q -> Action a) -> S.Rules (q -> Action a)
+addOracle :: (RuleResult q ~ a, S.ShakeValue q, S.ShakeValue a) => (q -> Action a) -> S.Rules (q -> Action a)
 addOracle action = do
     query <- S.addOracle (\q -> wrapAction (action q) (show q))
     return $ liftAction . query

--- a/src/Development/Shake/Fancy.hs
+++ b/src/Development/Shake/Fancy.hs
@@ -54,6 +54,7 @@ import System.Console.Concurrent
 import System.Console.Regions
 import Control.Monad.Trans.Reader
 import Control.Monad.IO.Class
+import Control.Monad.Fail
 import Control.Monad
 import Control.Applicative
 import Data.List
@@ -73,7 +74,7 @@ data FancyEnv = FancyEnv
 
 -- | Wrapper around 'S.Action'
 newtype Action a = Action (ReaderT FancyEnv S.Action a)
-    deriving (Monad, Applicative, Functor, MonadIO)
+    deriving (Monad, Applicative, Functor, MonadIO, MonadFail)
 
 runAction :: Action a -> FancyEnv -> S.Action a
 runAction (Action fa) = runReaderT fa

--- a/src/Shake.hs
+++ b/src/Shake.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving, NondecreasingIndentation #-}
+{-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving, NondecreasingIndentation, TypeFamilies #-}
 module Shake where
 
 import Development.Shake.Fancy hiding (withTempFile)
@@ -90,13 +90,17 @@ descendsFromStart s hash = case S.start s of
 
 newtype LimitRecent = LimitRecent ()
     deriving (Show,Typeable,Eq,Hashable,Binary,NFData)
+type instance RuleResult LimitRecent = Integer
 
 newtype GetIndexHTMLFile = GetIndexHTMLFile ()
     deriving (Show,Typeable,Eq,Hashable,Binary,NFData)
+type instance RuleResult GetIndexHTMLFile = BS.ByteString
 newtype GetGipedaJSFile = GetGipedaJSFile ()
     deriving (Show,Typeable,Eq,Hashable,Binary,NFData)
+type instance RuleResult GetGipedaJSFile = BS.ByteString
 newtype GetInstallJSLibsScript = GetInstallJSLibsScript ()
     deriving (Show,Typeable,Eq,Hashable,Binary,NFData)
+type instance RuleResult GetInstallJSLibsScript = BS.ByteString
 
 data LogSource = FileSystem | BareGit | NoLogs deriving Show
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,9 @@
-resolver: lts-6.2
+resolver: lts-13.18
 
 packages:
 - '.'
 
-extra-deps: []
-
-flags: {}
-
-extra-package-dbs: []
+extra-deps:
+- gitlib-3.1.2@sha256:0f7142d8d58f7717242d65238e8814f17f9bbe7224a463adf34f75262c536227
+- gitlib-libgit2-3.1.2.1@sha256:36bc92f117158440ca69e32051aabdf9df75be8a3fb5f45dff8828898e615a0a
 


### PR DESCRIPTION
This PR makes Gipeda compatible with recent versions of its dependencies, including recent versions of `base` and `shake`.
Note that the builtin rules are currently defined very pessimistically, i.e. they are always considered out-of-date. This ensures that the rules are correct, but on the other hand they might be defined more optimistically (increasing performance).